### PR TITLE
ISSUE-31 - Implement Standardized type-safe SeleniumErrors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
-/.build
+**/.build
+**/.index-build
 /Packages
 /*.xcodeproj
 xcuserdata/

--- a/Sources/SwiftWebDriver/Element/Element.swift
+++ b/Sources/SwiftWebDriver/Element/Element.swift
@@ -145,12 +145,8 @@ public struct Element: ElementCommandProtocol, Sendable {
         } catch {
             guard
                 retryCount > 0,
-                let error = error as? SeleniumError
+                let error = error.asSeleniumError(ofType: .noSuchElement)
             else { return false }
-
-            guard error.value.error == "no such element" else {
-                return false
-            }
 
             let retryCount = retryCount - 1
 

--- a/Sources/SwiftWebDriver/Element/Element.swift
+++ b/Sources/SwiftWebDriver/Element/Element.swift
@@ -146,7 +146,9 @@ public struct Element: ElementCommandProtocol, Sendable {
             guard
                 retryCount > 0,
                 error.isSeleniumError(ofType: .noSuchElement)
-            else { return false }
+            else {
+                return false
+            }
 
             let retryCount = retryCount - 1
 

--- a/Sources/SwiftWebDriver/Element/Element.swift
+++ b/Sources/SwiftWebDriver/Element/Element.swift
@@ -145,7 +145,7 @@ public struct Element: ElementCommandProtocol, Sendable {
         } catch {
             guard
                 retryCount > 0,
-                let error = error.asSeleniumError(ofType: .noSuchElement)
+                error.isSeleniumError(ofType: .noSuchElement)
             else { return false }
 
             let retryCount = retryCount - 1

--- a/Sources/SwiftWebDriver/Element/Elements.swift
+++ b/Sources/SwiftWebDriver/Element/Elements.swift
@@ -107,7 +107,7 @@ public extension Elements {
         } catch {
             guard
                 retryCount > 0,
-                let error = error.asSeleniumError(ofType: .noSuchElement)
+                error.isSeleniumError(ofType: .noSuchElement)
             else { return false }
 
             let retryCount = retryCount - 1

--- a/Sources/SwiftWebDriver/Element/Elements.swift
+++ b/Sources/SwiftWebDriver/Element/Elements.swift
@@ -107,12 +107,8 @@ public extension Elements {
         } catch {
             guard
                 retryCount > 0,
-                let error = error as? SeleniumError
+                let error = error.asSeleniumError(ofType: .noSuchElement)
             else { return false }
-
-            guard error.value.error == "no such element" else {
-                return false
-            }
 
             let retryCount = retryCount - 1
 

--- a/Sources/SwiftWebDriver/Error/SeleniumError.swift
+++ b/Sources/SwiftWebDriver/Error/SeleniumError.swift
@@ -8,16 +8,62 @@
 
 import Foundation
 
+/// https://www.selenium.dev/documentation/legacy/json_wire_protocol/#error-handling
+public enum SeleniumErrorType: String, Codable {
+    case elementClickIntercepted = "element click intercepted"
+    case elementNotInteractable = "element not interactable"
+    case elementNotSelectable = "element not selectable"
+    case elementNotVisible = "element not visible"
+    case invalidArgument = "invalid argument"
+    case invalidCookieDomain = "invalid cookie domain"
+    case invalidElementState = "invalid element state"
+    case invalidSelector = "invalid selector"
+    case javascriptError = "javascript error"
+    case moveTargetOutOfBounds = "move target out of bounds"
+    case noSuchAlert = "no such alert"
+    case noSuchElement = "no such element"
+    case noSuchFrame = "no such frame"
+    case noSuchWindow = "no such window"
+    case scriptTimeout = "script timeout"
+    case sessionNotCreated = "session not created"
+    case staleElementReference = "stale element reference"
+    case timeout = "timeout"
+    case unableToSetCookie = "unable to set cookie"
+    case unexpectedAlertOpen = "unexpected alert open"
+    case unknownCommand = "unknown command"
+    case unknownError = "unknown error"
+    case unsupportedOperation = "unsupported operation"
+
+    /// Fallback for unknown errors
+    case unrecognized
+}
+
 public struct SeleniumError: Codable, LocalizedError {
     public let value: Value
+
     public var errorDescription: String? {
-        "error : \(value.error), message: \(value.message)"
+        "error : \(errorType), message: \(value.message)"
+    }
+
+    public var errorType: SeleniumErrorType {
+        SeleniumErrorType(rawValue: value.error) ?? .unrecognized
+    }
+
+    public struct Value: Codable, Sendable {
+        public let message: String
+        public let error: String
     }
 }
 
-public extension SeleniumError {
-    struct Value: Codable, Sendable {
-        public let message: String
-        public let error: String
+public extension Error {
+    public func isSeleniumError(ofType type: SeleniumErrorType) -> Bool {
+        guard let seleniumError = self as? SeleniumError else { return false }
+        return seleniumError.errorType == type
+    }
+
+    public func asSeleniumError(ofType type: SeleniumErrorType) -> SeleniumError? {
+        guard let seleniumError = self as? SeleniumError,
+              seleniumError.errorType == type else { return nil }
+        return seleniumError
     }
 }

--- a/Sources/SwiftWebDriver/Error/SeleniumError.swift
+++ b/Sources/SwiftWebDriver/Error/SeleniumError.swift
@@ -27,7 +27,7 @@ public enum SeleniumErrorType: String, Codable {
     case scriptTimeout = "script timeout"
     case sessionNotCreated = "session not created"
     case staleElementReference = "stale element reference"
-    case timeout
+    case timeout = "timeout"
     case unableToSetCookie = "unable to set cookie"
     case unexpectedAlertOpen = "unexpected alert open"
     case unknownCommand = "unknown command"

--- a/Sources/SwiftWebDriver/Error/SeleniumError.swift
+++ b/Sources/SwiftWebDriver/Error/SeleniumError.swift
@@ -27,7 +27,7 @@ public enum SeleniumErrorType: String, Codable {
     case scriptTimeout = "script timeout"
     case sessionNotCreated = "session not created"
     case staleElementReference = "stale element reference"
-    case timeout = "timeout"
+    case timeout
     case unableToSetCookie = "unable to set cookie"
     case unexpectedAlertOpen = "unexpected alert open"
     case unknownCommand = "unknown command"
@@ -56,12 +56,12 @@ public struct SeleniumError: Codable, LocalizedError {
 }
 
 public extension Error {
-    public func isSeleniumError(ofType type: SeleniumErrorType) -> Bool {
+    func isSeleniumError(ofType type: SeleniumErrorType) -> Bool {
         guard let seleniumError = self as? SeleniumError else { return false }
         return seleniumError.errorType == type
     }
 
-    public func asSeleniumError(ofType type: SeleniumErrorType) -> SeleniumError? {
+    func asSeleniumError(ofType type: SeleniumErrorType) -> SeleniumError? {
         guard let seleniumError = self as? SeleniumError,
               seleniumError.errorType == type else { return nil }
         return seleniumError

--- a/Sources/SwiftWebDriver/WebDrivers/Chrome/ChromeDriver.swift
+++ b/Sources/SwiftWebDriver/WebDrivers/Chrome/ChromeDriver.swift
@@ -234,12 +234,8 @@ public class ChromeDriver: Driver {
         } catch {
             guard
                 retryCount > 0,
-                let error = error as? SeleniumError
+                let error = error.asSeleniumError(ofType: .noSuchElement)
             else { return false }
-
-            guard error.value.error == "no such element" else {
-                return false
-            }
 
             let retryCount = retryCount - 1
 

--- a/Sources/SwiftWebDriver/WebDrivers/Chrome/ChromeDriver.swift
+++ b/Sources/SwiftWebDriver/WebDrivers/Chrome/ChromeDriver.swift
@@ -235,7 +235,9 @@ public class ChromeDriver: Driver {
             guard
                 retryCount > 0,
                 error.isSeleniumError(ofType: .noSuchElement)
-            else { return false }
+            else {
+                return false
+            }
 
             let retryCount = retryCount - 1
 

--- a/Sources/SwiftWebDriver/WebDrivers/Chrome/ChromeDriver.swift
+++ b/Sources/SwiftWebDriver/WebDrivers/Chrome/ChromeDriver.swift
@@ -234,7 +234,7 @@ public class ChromeDriver: Driver {
         } catch {
             guard
                 retryCount > 0,
-                let error = error.asSeleniumError(ofType: .noSuchElement)
+                error.isSeleniumError(ofType: .noSuchElement)
             else { return false }
 
             let retryCount = retryCount - 1

--- a/Tests/SwiftWebDriverIntegrationTests/ChromeDriver/DevTools/ChromeDriverJavascriptIntegrationTests.swift
+++ b/Tests/SwiftWebDriverIntegrationTests/ChromeDriver/DevTools/ChromeDriverJavascriptIntegrationTests.swift
@@ -61,7 +61,7 @@ internal class ChromeDriverJavascriptIntegrationTests: ChromeDriverTest {
             try await driver.execute("throw new Error('Test Error')", args: [])
             try #require(Bool(false))
         } catch {
-            guard error is SeleniumError else {
+            guard error.isSeleniumError(ofType: .javascriptError) else {
                 try #require(Bool(false))
                 return
             }


### PR DESCRIPTION
# Reason

The Library currently doesn't support an easy way to recognize what type of exceptions are being thrown. This PR implements a similar concept to how alamofire adds an extension onto the generic error object to try and identify what type of error it is. This PR also touches all the tests that are looking for a specific exception type.

# Tech Details List

- Implements `isSeleniumError(ofType: SeleniumErrorType) -> Bool` that validates if an error is a specific type
- Implements `asSeleniumError(ofType: SeleniumErrorType) -> SeleniumError?` that returns a `SeleniumError` if the condition is met
- Implements a public enum `SeleniumErrorType` mapping error values
- Enhances all tests that checks for `SeleniumError` to also validate the error type that was thrown

**Tasks:**

- [x] Document testing Instructions
- [x] Refactor tests to check error type as well

**Links:**

[ISSUE-31](https://github.com/GetAutomaApp/AutomaInfraCore/issues/31)
resolves #31

# Testing

- Ensure unit tests pass